### PR TITLE
Fixes to release wheels for 3.14. Fix reference counting in dsdp.sdp() and adjust matrix strides for compatibility

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -65,7 +65,7 @@ jobs:
           echo "Building from commit: $(git rev-parse HEAD)"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.3
+        uses: pypa/cibuildwheel@v3.3.1
         env:
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}
           SETUPTOOLS_SCM_PRETEND_VERSION: ${{ inputs.scm_version }}

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -61,7 +61,7 @@ jobs:
           echo "Building from commit: $(git rev-parse HEAD)"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.3
+        uses: pypa/cibuildwheel@v3.3.1
         env:
           CIBW_ARCHS_MACOS: ${{ matrix.arch }}
           SETUPTOOLS_SCM_PRETEND_VERSION: ${{ inputs.scm_version }}

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -60,7 +60,7 @@ jobs:
           echo "Building from commit: $(git rev-parse HEAD)"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.3
+        uses: pypa/cibuildwheel@v3.3.1
         env:
           CIBW_ARCHS_WINDOWS: ${{ matrix.arch }}
           SETUPTOOLS_SCM_PRETEND_VERSION: ${{ inputs.scm_version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ local_scheme = "no-local-version"
 
 [tool.cibuildwheel]
 build = "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"
-enable = "cpython-prerelease"
 skip = ["cp*-win32", "cp*-manylinux_i686", "pp*"]
 test-requires = ["numpy", "pytest"]
 test-command = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ local_scheme = "no-local-version"
 
 [tool.cibuildwheel]
 build = "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"
+enable = "cpython-prerelease"
 skip = ["cp*-win32", "cp*-manylinux_i686", "pp*"]
 test-requires = ["numpy", "pytest"]
 test-command = [

--- a/src/C/dense.c
+++ b/src/C/dense.c
@@ -163,8 +163,8 @@ matrix * Matrix_New(int nrows, int ncols, int id)
   a->ob_exports = 0;
   a->shape[0] = nrows;
   a->shape[1] = ncols;
-  a->strides[0] = ncols * E_SIZE[a->id];
-  a->strides[1] = E_SIZE[a->id];
+  a->strides[0] = E_SIZE[a->id];
+  a->strides[1] = nrows * E_SIZE[a->id];
   if ((a->buffer = calloc(nrows*ncols,E_SIZE[id])))
     return a;
   else if (nrows*ncols == 0) 

--- a/src/C/dsdp.c
+++ b/src/C/dsdp.c
@@ -176,14 +176,17 @@ static PyObject* solvesdp(PyObject *self, PyObject *args,
         goto done;
     }
 
-    if (opts && PyDict_Check(opts))
+    if (opts && PyDict_Check(opts)) {
+        Py_INCREF(opts);
         param = opts;
+    }
     else
         param = PyObject_GetAttrString(dsdp_module, "options");
     if (!param || !PyDict_Check(param)){
         PyErr_SetString(PyExc_AttributeError, "missing dsdp.options "
             " dictionary");
         t = NULL;
+        Py_XDECREF(param);
         goto done;
     }
     while (PyDict_Next(param, &pos, &key, &value))


### PR DESCRIPTION
Correct reference counting in the `dsdp.sdp()` function and fix matrix stride calculations to ensure proper functionality with the cpython-prerelease builds.